### PR TITLE
docs: :books: enhance documentation

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -59,7 +59,7 @@ return $config->setRules([
     'normalize_index_brace' => true,
     'object_operator_without_whitespace' => true,
     'ordered_imports' => ['sort_algorithm' => 'alpha'],
-    'phpdoc_align' => ['align' => 'left'],
+    'phpdoc_align' => ['align' => 'vertical'],
     'phpdoc_indent' => true,
     'phpdoc_no_access' => true,
     'phpdoc_no_package' => true,

--- a/README.md
+++ b/README.md
@@ -6,13 +6,16 @@ A lightweight, framework-agnostic JWT authentication orchestrator for PHP, built
 
 This library provides a clean, contract-driven approach to JSON Web Token authentication by coordinating token issuance and parsing while delegating token handling, user resolution, and claims generation to user-defined implementations. By relying on simple interfaces, it remains fully framework-agnostic and unopinionated, allowing integration with any authentication system or JWT library.
 
+## 📋 Prerequisites
+
+- **[PHP](https://www.php.net/)**: Version 8.3 or higher is required.
+- **[Composer](https://getcomposer.org/)**: Dependency management tool for PHP.
+
 ## 📥 Installation
 
 ```bash
 composer require andrewdyer/jwt-auth
 ```
-
-Requires PHP 8.3 or newer.
 
 ## 🚀 Getting Started
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A lightweight, framework-agnostic JWT authentication orchestrator for PHP, built around contracts for user resolution, token handling, and claims generation.
 
-## Introduction
+## ✨ Introduction
 
 This library provides a clean, contract-driven approach to JSON Web Token authentication by coordinating token issuance and parsing while delegating token handling, user resolution, and claims generation to user-defined implementations. By relying on simple interfaces, it remains fully framework-agnostic and unopinionated, allowing integration with any authentication system or JWT library.
 
-## Installation
+## 📥 Installation
 
 ```bash
 composer require andrewdyer/jwt-auth
@@ -14,7 +14,7 @@ composer require andrewdyer/jwt-auth
 
 Requires PHP 8.3 or newer.
 
-## Getting Started
+## 🚀 Getting Started
 
 ### 1. Implement the JWT subject
 
@@ -106,7 +106,7 @@ class MyClaimsFactory implements ClaimsFactoryInterface
 
 When using Carbon, `Carbon::now()->timestamp` is a drop-in replacement for `time()`.
 
-## Usage
+## 📚 Usage
 
 ### Create a JwtAuth instance
 
@@ -168,7 +168,7 @@ try {
 }
 ```
 
-## Claims
+## 🔑 Claims
 
 The `Claims` class is a read-only value object representing the payload of a JWT. It exposes the standard registered claims as typed public properties:
 
@@ -205,7 +205,7 @@ $claims = Claims::fromArray([
 
 Any keys not in the standard set are captured in the `custom` array.
 
-## Exceptions
+## ⚠️ Exceptions
 
 | Exception                     | Thrown when                                                                                                                     |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
@@ -214,6 +214,6 @@ Any keys not in the standard set are captured in the `custom` array.
 
 Both extend `RuntimeException`.
 
-## License
+## ⚖️ License
 
 Licensed under the [MIT license](https://opensource.org/licenses/MIT) and is free for private or commercial projects.

--- a/src/Claims.php
+++ b/src/Claims.php
@@ -6,8 +6,25 @@ namespace AndrewDyer\JwtAuth;
 
 use AndrewDyer\JwtAuth\Exceptions\InvalidTokenException;
 
+/**
+ * Represents the decoded payload of a JWT, encapsulating all standard
+ * registered claims alongside any custom (application-defined) claims.
+ *
+ * Instances are immutable; all properties are publicly readable but
+ * cannot be modified after construction.
+ */
 final readonly class Claims
 {
+    /**
+     * @param string               $iss    The issuer of the token — identifies the principal that issued the JWT.
+     * @param string|null          $aud    The intended audience of the token, or null if unrestricted.
+     * @param int                  $iat    Unix timestamp at which the token was issued.
+     * @param int                  $nbf    Unix timestamp before which the token must not be accepted.
+     * @param int                  $exp    Unix timestamp at which the token expires.
+     * @param string               $jti    A unique token identifier, typically used to prevent replay attacks.
+     * @param int|string           $sub    The subject of the token — the authenticated entity's unique identifier.
+     * @param array<string, mixed> $custom Additional application-defined claims to include in the payload.
+     */
     public function __construct(
         public string     $iss,
         public ?string    $aud,
@@ -20,6 +37,14 @@ final readonly class Claims
     ) {
     }
 
+    /**
+     * Serialises the claims to an associative array suitable for JWT encoding.
+     *
+     * Standard claims are merged with any custom claims. Null values (such as
+     * a missing audience) are omitted from the resulting array.
+     *
+     * @return array<string, mixed> The JWT payload as a key–value map.
+     */
     public function toArray(): array
     {
         return array_filter(array_merge([
@@ -33,6 +58,19 @@ final readonly class Claims
         ], $this->custom), static fn ($v) => $v !== null);
     }
 
+    /**
+     * Constructs a Claims instance from a raw decoded JWT payload array.
+     *
+     * Validates that all required claims are present and that each carries the
+     * expected type. Keys beyond the standard set are collected as custom claims
+     * and preserved without modification.
+     *
+     * @param array<string, mixed> $data The raw payload array decoded from a JWT.
+     *
+     * @return self A fully populated and validated Claims instance.
+     *
+     * @throws InvalidTokenException If a required claim is absent or any claim value has an invalid type.
+     */
     public static function fromArray(array $data): self
     {
         foreach (['iss', 'iat', 'nbf', 'exp', 'jti', 'sub'] as $key) {

--- a/src/Contracts/AuthProviderInterface.php
+++ b/src/Contracts/AuthProviderInterface.php
@@ -4,9 +4,30 @@ declare(strict_types=1);
 
 namespace AndrewDyer\JwtAuth\Contracts;
 
+/**
+ * Defines the contract for resolving authenticated subjects from credentials or identifiers.
+ *
+ * Implementations are responsible for looking up users (or any JWT-capable entity)
+ * from an underlying data source such as a database or in-memory store.
+ */
 interface AuthProviderInterface
 {
+    /**
+     * Retrieves a subject by verifying the provided credentials.
+     *
+     * @param string $username The username or email to look up.
+     * @param string $password The plain-text password to verify against the stored credential.
+     *
+     * @return JwtSubjectInterface|null The matching subject, or null if the credentials are invalid.
+     */
     public function byCredentials(string $username, string $password): ?JwtSubjectInterface;
 
+    /**
+     * Retrieves a subject by their unique identifier.
+     *
+     * @param int|string $id The unique identifier of the subject to resolve.
+     *
+     * @return JwtSubjectInterface|null The matching subject, or null if no subject exists for the given ID.
+     */
     public function byId(int|string $id): ?JwtSubjectInterface;
 }

--- a/src/Contracts/ClaimsFactoryInterface.php
+++ b/src/Contracts/ClaimsFactoryInterface.php
@@ -6,7 +6,20 @@ namespace AndrewDyer\JwtAuth\Contracts;
 
 use AndrewDyer\JwtAuth\Claims;
 
+/**
+ * Defines the contract for constructing a JWT claims payload for a given subject.
+ *
+ * Implementations control which claims are included in the token, covering
+ * standard registered claims (issuer, expiry, etc.) and any application-specific additions.
+ */
 interface ClaimsFactoryInterface
 {
+    /**
+     * Builds a Claims instance populated for the given JWT subject.
+     *
+     * @param JwtSubjectInterface $subject The entity for whom the token is being issued.
+     *
+     * @return Claims A fully populated Claims object ready for encoding.
+     */
     public function forSubject(JwtSubjectInterface $subject): Claims;
 }

--- a/src/Contracts/JwtProviderInterface.php
+++ b/src/Contracts/JwtProviderInterface.php
@@ -4,9 +4,30 @@ declare(strict_types=1);
 
 namespace AndrewDyer\JwtAuth\Contracts;
 
+/**
+ * Defines the contract for encoding and decoding JWT strings.
+ *
+ * Implementations wrap a concrete JWT library and expose a normalised interface
+ * so the rest of the package remains decoupled from any specific signing
+ * algorithm or third-party dependency.
+ */
 interface JwtProviderInterface
 {
+    /**
+     * Decodes a JWT string and returns its payload.
+     *
+     * @param string $token The signed JWT string to decode.
+     *
+     * @return mixed The decoded payload, typically an associative array or stdClass object.
+     */
     public function decode(string $token): mixed;
 
+    /**
+     * Encodes a claims array as a signed JWT string.
+     *
+     * @param array<string, mixed> $claims The claims payload to encode.
+     *
+     * @return string A signed JWT string representing the provided claims.
+     */
     public function encode(array $claims): string;
 }

--- a/src/Contracts/JwtProviderInterface.php
+++ b/src/Contracts/JwtProviderInterface.php
@@ -16,18 +16,18 @@ interface JwtProviderInterface
     /**
      * Decodes a JWT string and returns its payload.
      *
-     * @param string $token The signed JWT string to decode.
+     * @param string $token The JWT string to decode.
      *
      * @return mixed The decoded payload, typically an associative array or stdClass object.
      */
     public function decode(string $token): mixed;
 
     /**
-     * Encodes a claims array as a signed JWT string.
+     * Encodes a claims array as a JWT string.
      *
      * @param array<string, mixed> $claims The claims payload to encode.
      *
-     * @return string A signed JWT string representing the provided claims.
+     * @return string A JWT string representing the provided claims.
      */
     public function encode(array $claims): string;
 }

--- a/src/Contracts/JwtSubjectInterface.php
+++ b/src/Contracts/JwtSubjectInterface.php
@@ -4,7 +4,18 @@ declare(strict_types=1);
 
 namespace AndrewDyer\JwtAuth\Contracts;
 
+/**
+ * Defines the contract for entities that can be represented as the subject of a JWT.
+ *
+ * Any model or entity that participates in JWT authentication must implement
+ * this interface so that its identifier can be embedded as the `sub` claim.
+ */
 interface JwtSubjectInterface
 {
+    /**
+     * Returns the unique identifier used as the `sub` claim in the JWT.
+     *
+     * @return int|string The subject identifier — typically a user ID or UUID.
+     */
     public function getJwtIdentifier(): int|string;
 }

--- a/src/Exceptions/InvalidCredentialsException.php
+++ b/src/Exceptions/InvalidCredentialsException.php
@@ -7,8 +7,19 @@ namespace AndrewDyer\JwtAuth\Exceptions;
 use RuntimeException;
 use Throwable;
 
+/**
+ * Thrown when authentication fails due to invalid or unrecognised credentials.
+ *
+ * Raised by the authentication layer when a username/password pair does not
+ * match any known subject in the underlying data source.
+ */
 final class InvalidCredentialsException extends RuntimeException
 {
+    /**
+     * @param string         $message  A human-readable description of the authentication failure.
+     * @param int            $code     An application-specific error code.
+     * @param Throwable|null $previous The previous exception, if this was thrown as part of a chain.
+     */
     public function __construct(string $message = 'Invalid credentials provided.', int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);

--- a/src/Exceptions/InvalidTokenException.php
+++ b/src/Exceptions/InvalidTokenException.php
@@ -7,8 +7,19 @@ namespace AndrewDyer\JwtAuth\Exceptions;
 use RuntimeException;
 use Throwable;
 
+/**
+ * Thrown when a JWT is malformed, missing required claims, or contains invalid claim values.
+ *
+ * Raised during token decoding or claim validation when the provided token cannot
+ * be trusted or does not conform to the expected structure.
+ */
 final class InvalidTokenException extends RuntimeException
 {
+    /**
+     * @param string         $message  A human-readable description of why the token was rejected.
+     * @param int            $code     An application-specific error code.
+     * @param Throwable|null $previous The previous exception, if this was thrown as part of a chain.
+     */
     public function __construct(string $message = 'Invalid token provided.', int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);

--- a/src/JwtAuth.php
+++ b/src/JwtAuth.php
@@ -32,12 +32,12 @@ final readonly class JwtAuth
     }
 
     /**
-     * Validates the provided credentials and issues a signed JWT on success.
+     * Validates the provided credentials and issues a JWT string on success.
      *
      * @param string $username The username or email to authenticate with.
      * @param string $password The plain-text password to verify.
      *
-     * @return string A signed JWT string for the authenticated subject.
+     * @return string A JWT string for the authenticated subject, as produced by the JwtProviderInterface implementation.
      *
      * @throws InvalidCredentialsException If the credentials do not match any known subject.
      */
@@ -55,7 +55,7 @@ final readonly class JwtAuth
     /**
      * Parses the given token, resolves the subject it identifies, and returns it.
      *
-     * @param string $token A signed JWT string to authenticate against.
+     * @param string $token A JWT string to authenticate against.
      *
      * @return JwtSubjectInterface The authenticated subject identified by the token's subject claim.
      *
@@ -95,11 +95,11 @@ final readonly class JwtAuth
     }
 
     /**
-     * Builds a claims payload for the given subject and encodes it as a signed JWT string.
+     * Builds a claims payload for the given subject and encodes it as a JWT string.
      *
      * @param JwtSubjectInterface $subject The authenticated entity for whom the token is issued.
      *
-     * @return string A signed JWT string encoding the subject's claims.
+     * @return string A JWT string encoding the subject's claims, as produced by the JwtProviderInterface implementation.
      */
     private function fromSubject(JwtSubjectInterface $subject): string
     {

--- a/src/JwtAuth.php
+++ b/src/JwtAuth.php
@@ -11,8 +11,19 @@ use AndrewDyer\JwtAuth\Contracts\JwtSubjectInterface;
 use AndrewDyer\JwtAuth\Exceptions\InvalidCredentialsException;
 use AndrewDyer\JwtAuth\Exceptions\InvalidTokenException;
 
+/**
+ * Entry point for JWT-based authentication.
+ *
+ * Orchestrates credential validation, token issuance, and token verification
+ * by delegating to the injected authentication, JWT, and claims-factory providers.
+ */
 final readonly class JwtAuth
 {
+    /**
+     * @param AuthProviderInterface  $authProvider  Resolves authenticated subjects from credentials or identifiers.
+     * @param JwtProviderInterface   $jwtProvider   Handles encoding and decoding of JWT strings.
+     * @param ClaimsFactoryInterface $claimsFactory Constructs the claims payload for a given subject.
+     */
     public function __construct(
         private AuthProviderInterface $authProvider,
         private JwtProviderInterface $jwtProvider,
@@ -20,6 +31,16 @@ final readonly class JwtAuth
     ) {
     }
 
+    /**
+     * Validates the provided credentials and issues a signed JWT on success.
+     *
+     * @param string $username The username or email to authenticate with.
+     * @param string $password The plain-text password to verify.
+     *
+     * @return string A signed JWT string for the authenticated subject.
+     *
+     * @throws InvalidCredentialsException If the credentials do not match any known subject.
+     */
     public function attempt(string $username, string $password): string
     {
         $user = $this->authProvider->byCredentials($username, $password);
@@ -31,6 +52,15 @@ final readonly class JwtAuth
         return $this->fromSubject($user);
     }
 
+    /**
+     * Parses the given token, resolves the subject it identifies, and returns it.
+     *
+     * @param string $token A signed JWT string to authenticate against.
+     *
+     * @return JwtSubjectInterface The authenticated subject identified by the token's subject claim.
+     *
+     * @throws InvalidTokenException If the token is invalid or no subject is found for the encoded identifier.
+     */
     public function authenticate(string $token): JwtSubjectInterface
     {
         $claims = $this->parse($token);
@@ -44,6 +74,15 @@ final readonly class JwtAuth
         return $user;
     }
 
+    /**
+     * Decodes a JWT string and returns a typed Claims object.
+     *
+     * @param string $token The raw JWT string to decode and validate.
+     *
+     * @return Claims The structured and validated claims extracted from the token.
+     *
+     * @throws InvalidTokenException If the token cannot be decoded or does not yield a valid payload.
+     */
     public function parse(string $token): Claims
     {
         $decoded = $this->jwtProvider->decode($token);
@@ -55,6 +94,13 @@ final readonly class JwtAuth
         return Claims::fromArray((array)$decoded);
     }
 
+    /**
+     * Builds a claims payload for the given subject and encodes it as a signed JWT string.
+     *
+     * @param JwtSubjectInterface $subject The authenticated entity for whom the token is issued.
+     *
+     * @return string A signed JWT string encoding the subject's claims.
+     */
     private function fromSubject(JwtSubjectInterface $subject): string
     {
         $claims = $this->claimsFactory->forSubject($subject);

--- a/tests/Support/ArrayJwtProvider.php
+++ b/tests/Support/ArrayJwtProvider.php
@@ -6,15 +6,43 @@ namespace AndrewDyer\JwtAuth\Tests\Support;
 
 use AndrewDyer\JwtAuth\Contracts\JwtProviderInterface;
 
+/**
+ * In-memory JWT provider for use in tests.
+ *
+ * Tokens are not cryptographically signed; the claims payload is serialised
+ * as base64-encoded JSON. This keeps tests fast and free from signature
+ * configuration while still exercising the full encode/decode flow.
+ */
 final class ArrayJwtProvider implements JwtProviderInterface
 {
+    /**
+     * The claims array from the most recent call to encode().
+     *
+     * Exposed publicly so tests can assert on the exact payload that was encoded.
+     *
+     * @var array<string, mixed>
+     */
     public array $lastEncoded = [];
 
+    /**
+     * Decodes a base64-encoded JSON token and returns its payload as a plain object.
+     *
+     * @param string $token The base64-encoded JSON string to decode.
+     *
+     * @return mixed The decoded payload, typically a stdClass object.
+     */
     public function decode(string $token): mixed
     {
         return json_decode(base64_decode($token));
     }
 
+    /**
+     * Encodes a claims array as a base64-encoded JSON string and stores it for later inspection.
+     *
+     * @param array<string, mixed> $claims The claims payload to encode.
+     *
+     * @return string A base64-encoded JSON representation of the provided claims.
+     */
     public function encode(array $claims): string
     {
         $this->lastEncoded = $claims;

--- a/tests/Support/ClaimsFactory.php
+++ b/tests/Support/ClaimsFactory.php
@@ -8,14 +8,34 @@ use AndrewDyer\JwtAuth\Claims;
 use AndrewDyer\JwtAuth\Contracts\ClaimsFactoryInterface;
 use AndrewDyer\JwtAuth\Contracts\JwtSubjectInterface;
 
+/**
+ * Test-only claims factory that produces a deterministic Claims object for a given subject.
+ *
+ * Time values are injected via the constructor, making token expiry fully predictable
+ * in tests without relying on the system clock.
+ */
 final readonly class ClaimsFactory implements ClaimsFactoryInterface
 {
+    /**
+     * @param int $now The Unix timestamp used as both the issued-at (iat) and not-before (nbf) claims.
+     * @param int $ttl The token lifetime in seconds, added to $now to derive the expiry (exp) claim.
+     */
     public function __construct(
         private int $now,
         private int $ttl = 3600,
     ) {
     }
 
+    /**
+     * Constructs a Claims instance for the given subject using the factory's fixed timestamps.
+     *
+     * A random JTI is generated on each call to ensure token uniqueness across
+     * multiple invocations within the same test scenario.
+     *
+     * @param JwtSubjectInterface $subject The entity for whom the token is being issued.
+     *
+     * @return Claims A fully populated Claims object with deterministic time values.
+     */
     public function forSubject(JwtSubjectInterface $subject): Claims
     {
         return new Claims(

--- a/tests/Support/InMemoryAuthProvider.php
+++ b/tests/Support/InMemoryAuthProvider.php
@@ -7,18 +7,43 @@ namespace AndrewDyer\JwtAuth\Tests\Support;
 use AndrewDyer\JwtAuth\Contracts\AuthProviderInterface;
 use AndrewDyer\JwtAuth\Contracts\JwtSubjectInterface;
 
+/**
+ * Stub authentication provider for use in tests.
+ *
+ * Always returns the same preset subject regardless of the credentials or
+ * identifier provided. Passing null allows simulating a failed lookup.
+ */
 final readonly class InMemoryAuthProvider implements AuthProviderInterface
 {
+    /**
+     * @param JwtSubjectInterface|null $user The subject to return for every authentication attempt,
+     *                                       or null to simulate a failed lookup.
+     */
     public function __construct(
         private ?JwtSubjectInterface $user = null
     ) {
     }
 
+    /**
+     * Returns the preset subject regardless of the supplied credentials.
+     *
+     * @param string $username The username provided for authentication (ignored in this stub).
+     * @param string $password The password provided for authentication (ignored in this stub).
+     *
+     * @return JwtSubjectInterface|null The preset subject, or null if none was configured.
+     */
     public function byCredentials(string $username, string $password): ?JwtSubjectInterface
     {
         return $this->user;
     }
 
+    /**
+     * Returns the preset subject regardless of the supplied identifier.
+     *
+     * @param int|string $id The identifier used to look up a subject (ignored in this stub).
+     *
+     * @return JwtSubjectInterface|null The preset subject, or null if none was configured.
+     */
     public function byId(int|string $id): ?JwtSubjectInterface
     {
         return $this->user;

--- a/tests/Support/User.php
+++ b/tests/Support/User.php
@@ -6,12 +6,26 @@ namespace AndrewDyer\JwtAuth\Tests\Support;
 
 use AndrewDyer\JwtAuth\Contracts\JwtSubjectInterface;
 
+/**
+ * Minimal JwtSubjectInterface implementation representing a test user.
+ *
+ * Used across unit tests to provide a concrete subject without the overhead
+ * of a full domain model or database-backed entity.
+ */
 final readonly class User implements JwtSubjectInterface
 {
+    /**
+     * @param int|string $id The unique identifier for this user, used as the JWT subject claim.
+     */
     public function __construct(private int|string $id)
     {
     }
 
+    /**
+     * Returns the user's unique identifier for use as the `sub` claim in a JWT.
+     *
+     * @return int|string The user's identifier.
+     */
     public function getJwtIdentifier(): int|string
     {
         return $this->id;


### PR DESCRIPTION
This pull request introduces comprehensive PHPDoc documentation across the core library, contracts, exceptions, and test support classes to improve code readability, maintainability, and IDE support. Additionally, it updates the documentation in `README.md` for clarity and consistency, and makes a minor adjustment to code style configuration.

**Documentation Improvements**

* Added detailed PHPDoc blocks to all public classes, constructors, and methods in the following core files: `src/Claims.php`, `src/JwtAuth.php`, and all files in `src/Contracts/` and `src/Exceptions/`. This includes descriptions of purpose, parameters, return types, and exception cases. [[1]](diffhunk://#diff-231d8d2f32afccbe65d572d9a407fddb1c9498f29da0885df027bf8b2845b19eR9-R27) [[2]](diffhunk://#diff-231d8d2f32afccbe65d572d9a407fddb1c9498f29da0885df027bf8b2845b19eR40-R47) [[3]](diffhunk://#diff-231d8d2f32afccbe65d572d9a407fddb1c9498f29da0885df027bf8b2845b19eR61-R73) [[4]](diffhunk://#diff-11e2acb9c08976097c75f982cf2180b159b2df7a3d98230f6c224e5daff54703R7-R31) [[5]](diffhunk://#diff-de5ab3fd2feac096cd9368727a6391836ba77003b011ac3f219d3f1be6b7b1a5R9-R23) [[6]](diffhunk://#diff-e98fc138d148511dc3bb5853f6c64f54a5b044473e0f03055cc2bcbc2b3ef9f3R7-R31) [[7]](diffhunk://#diff-95b01a5dde35f91c819180cc58000679fdadcb82185ab2c06d39b50373acc11dR7-R19) [[8]](diffhunk://#diff-06f2435c6b315ec979fb28a29ee28b44be9b22500457fb2b08d45f6a452c3a00R10-R22) [[9]](diffhunk://#diff-faa1b15994db89e0136d9ee2650ee94cfe28d243a134fe4a022175aa2a54579fR10-R22) [[10]](diffhunk://#diff-f018851d574452afcbf3a6705defc46d153e7547dd2d7706963f89664f98f623R14-R43) [[11]](diffhunk://#diff-f018851d574452afcbf3a6705defc46d153e7547dd2d7706963f89664f98f623R55-R63) [[12]](diffhunk://#diff-f018851d574452afcbf3a6705defc46d153e7547dd2d7706963f89664f98f623R77-R85) [[13]](diffhunk://#diff-f018851d574452afcbf3a6705defc46d153e7547dd2d7706963f89664f98f623R97-R103)

* Added PHPDoc to all test support classes (`tests/Support/ArrayJwtProvider.php`, `tests/Support/ClaimsFactory.php`, `tests/Support/InMemoryAuthProvider.php`) to clarify their purpose and usage in the test suite. [[1]](diffhunk://#diff-fadc5f07910829906fc2e3f6a95bb8316a96ee71b7137e602147f2d80148fdebR9-R45) [[2]](diffhunk://#diff-74cdcbcaf0e53f72bf6f826c2bed3a2f6e8a571545855aa590dae6c09955a468R11-R38) [[3]](diffhunk://#diff-6bdc4c5b440097c6ef3db5cf17cf065eec7c535281453ca1691cdbcab2559d78R10-R46)

**Documentation and Style Updates**

* Enhanced the `README.md` with improved section headers, added prerequisite information, and clarified usage instructions for better onboarding and comprehension. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109-R112) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L171-R174) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L208-R211) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L217-R220)

* Updated the PHP CS Fixer configuration to align PHPDoc comments vertically instead of left-aligned for improved readability. (`.php-cs-fixer.dist.php`)